### PR TITLE
Switching to case insensitivity led to an infinite loop of self-responses.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,13 +6,13 @@ from opsdroid.skill import Skill
 
 class HelloByeSkill(Skill):
 
-    @match_regex(r'hi|hello|hey|hallo')
+    @match_regex(r'hi|hello|hey|hallo', case_sensitive=False)
     async def hello(self, message):
         text = random.choice(
             ["Hi {}", "Hello {}", "Hey {}"]).format(message.user)
         await message.respond(text)
 
-    @match_regex(r'bye( bye)?|see y(a|ou)|au revoir|gtg|I(\')?m off')
+    @match_regex(r'bye( bye)?|see y(a|ou)|au revoir|gtg|I(\')?m off', case_sensitive=False)
     async def goodbye(self, message):
         text = random.choice(
             ["Bye {}", "See you {}", "Au revoir {}"]).format(message.user)


### PR DESCRIPTION
Thanks for this great project! Taking this for a test drive, I was briefly stumped by the fact that "Hi" did not work. Then I thought to try "hi" and it did. Simple enough, but for the take of making the initial example as welcoming and sure-to-work-on-the-first-try as possible, it might make sense to make this case insensitive.

While running this against this branch I encountered a more important issue which I will report against the main repo and link from here shortly.